### PR TITLE
Update responses and HTTP status codes for registration actions

### DIFF
--- a/ompid/__init__.py
+++ b/ompid/__init__.py
@@ -2,8 +2,11 @@ import os
 from typing import List
 
 import yaml
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, Response, HTTPException
+from fastapi.encoders import jsonable_encoder
 from fastapi.params import Depends
+from fastapi.responses import JSONResponse
+from sqlalchemy import and_
 from sqlalchemy.orm import Session
 
 from ompid.models import Base, TopioUser, TopioUserCreate, TopioUserORM, \
@@ -36,8 +39,19 @@ def init_tables():
     Base.metadata.create_all(ompid.db.engine)
 
 
-@app.post('/users/register', response_model=TopioUser)
+@app.post('/users/register', response_model=TopioUser, responses={201: {"model": TopioUser}})
 async def register_user(topio_user: TopioUserCreate, db: Session = Depends(get_db)):
+
+    topio_user_orm = (
+        db
+        .query(TopioUserORM)
+        .filter(and_(TopioUserORM.name == topio_user.name, TopioUserORM.user_namespace == topio_user.user_namespace))
+        .first()
+    )
+
+    if not topio_user_orm is None:
+        return topio_user_orm
+
     topio_user_orm = TopioUserORM(
         name=topio_user.name, user_namespace=topio_user.user_namespace)
 
@@ -45,7 +59,8 @@ async def register_user(topio_user: TopioUserCreate, db: Session = Depends(get_d
     db.commit()
     db.refresh(topio_user_orm)
 
-    return topio_user_orm
+    topio_user_json = jsonable_encoder(topio_user_orm)
+    return JSONResponse(status_code=201, content=topio_user_json)
 
 
 @app.get('/users/{topio_user_id}', response_model=TopioUser)
@@ -56,9 +71,19 @@ async def get_user_info(topio_user_id: int, db: Session = Depends(get_db)):
     return topio_user_orm
 
 
-@app.post('/asset_types/register', response_model=TopioAssetType)
+@app.post('/asset_types/register', response_model=TopioAssetType, responses={201: {"model": TopioAssetType}})
 async def register_asset_type(
         topio_asset_type: TopioAssetType, db: Session = Depends(get_db)):
+
+    topio_asset_type_orm = (
+        db
+        .query(TopioAssetTypeORM)
+        .filter(and_(TopioAssetTypeORM.id == topio_asset_type.id, TopioAssetTypeORM.description == topio_asset_type.description))
+        .first()
+    )
+
+    if not topio_asset_type_orm is None:
+        return topio_asset_type_orm
 
     topio_asset_type_orm = TopioAssetTypeORM(
         id=topio_asset_type.id, description=topio_asset_type.description)
@@ -67,7 +92,8 @@ async def register_asset_type(
     db.commit()
     db.refresh(topio_asset_type_orm)
 
-    return topio_asset_type_orm
+    topio_asset_type_json = jsonable_encoder(topio_asset_type_orm)
+    return JSONResponse(status_code=201, content=topio_asset_type_json)
 
 
 @app.get('/asset_types/{topio_asset_type_id}', response_model=TopioAssetType)
@@ -102,7 +128,7 @@ async def register_asset(topio_asset: TopioAssetCreate, db: Session = Depends(ge
     return topio_asset_orm
 
 
-@app.get('/assets/topio_id', response_model=str)
+@app.get('/assets/topio_id', response_model=str, responses={404: {"model": str}})
 async def get_topio_id(
         asset_info: TopioAssetCreate,
         db: Session = Depends(get_db)):
@@ -130,6 +156,9 @@ async def get_topio_id(
                 TopioAssetORM.asset_type == asset_info.asset_type,
                 TopioAssetORM.local_id == asset_info.local_id)\
         .first()
+
+    if asset is None:
+        return Response(status_code=404, content='No topio ID found for the given parameters')
 
     return asset.topio_id
 

--- a/ompid/__init__.py
+++ b/ompid/__init__.py
@@ -130,7 +130,9 @@ async def register_asset(topio_asset: TopioAssetCreate, db: Session = Depends(ge
 
 @app.get('/assets/topio_id', response_model=str, responses={404: {"model": str}})
 async def get_topio_id(
-        asset_info: TopioAssetCreate,
+        owner_id: int,
+        asset_type: str, 
+        local_id: str,
         db: Session = Depends(get_db)):
     """
     Returns the topio ID for a given asset identified by
@@ -138,23 +140,19 @@ async def get_topio_id(
     - the asset type
     - the asset's local ID (e.g. hdfs://foo/bar, postgresql://user:pw@dbhost/db)
 
-    :param asset_info: basic asset information which has to comprise the asset
-        owner ID, the asset type and the asset's local ID
+    :param owner_id: the asset owner ID
+    :param asset_type: the asset type
+    :param local_id: the asset's local ID
     :param db: database session (will be provided by FastAPI's dependency
         injection mechanism.
     :return: A string containing the topio ID of the respective asset
     """
 
-    if asset_info.local_id is None:
-        raise HTTPException(
-            status_code=400,
-            detail='No asset local ID provided')
-
     asset = db\
         .query(TopioAssetORM)\
-        .filter(TopioAssetORM.owner_id == asset_info.owner_id,
-                TopioAssetORM.asset_type == asset_info.asset_type,
-                TopioAssetORM.local_id == asset_info.local_id)\
+        .filter(TopioAssetORM.owner_id == owner_id,
+                TopioAssetORM.asset_type == asset_type,
+                TopioAssetORM.local_id == local_id)\
         .first()
 
     if asset is None:

--- a/tests/ompid/app_test.py
+++ b/tests/ompid/app_test.py
@@ -396,21 +396,22 @@ def test_assets_topio_id(postgresql: connection):
     asset_2_id = json.loads(response.content)['id']
     del response
 
-    # Calling /assets/topio_id with an undefined local ID should always return
-    # a client error
+    # Calling /assets/topio_id with an undefined parameter
     response = client.get(
         '/assets/topio_id',
-        json={
+        params={
             'owner_id': owner_id,
-            'asset_type': asset_type_id})
+            'asset_type': asset_type_id,
+            'local_id': None})
 
-    assert response.status_code == 400
+    # should cause a client error 422 (Unprocessable Entity)...
+    assert response.status_code == 422
 
     # Calling /assets/topio_id providing a local ID should return the correct
     # result
     response = client.get(
         '/assets/topio_id',
-        json={
+        params={
             'owner_id': owner_id,
             'asset_type': asset_type_id,
             'local_id': asset_2_local_id})
@@ -428,7 +429,7 @@ def test_assets_topio_id(postgresql: connection):
     # return an error with 404 status code
     response = client.get(
         '/assets/topio_id',
-        json={
+        params={
             'owner_id': 0,
             'asset_type': asset_type_id,
             'local_id': asset_2_local_id})

--- a/tests/ompid/app_test.py
+++ b/tests/ompid/app_test.py
@@ -43,7 +43,7 @@ def test_users_register(postgresql: connection):
         json={'name': user_name, 'user_namespace': user_namespace})
 
     # no errors were raised
-    assert response.status_code == 200
+    assert response.status_code == 201
 
     # user data can be found in the database
     user_id: int = json.loads(response.content)['id']
@@ -55,6 +55,14 @@ def test_users_register(postgresql: connection):
     results = cur.fetchall()
     cur.close()
     assert len(results) == 1
+
+    # existing user ---------------------------------------
+    response = client.post(
+        '/users/register',
+        json={'name': user_name, 'user_namespace': user_namespace})
+
+    # no errors were raised
+    assert response.status_code == 200
 
     # user with broken namespace (contains whitespace) ----
     user_name = 'User DEF'
@@ -117,7 +125,7 @@ def test_asset_types_register(postgresql: connection):
         json={'id': asset_type_id, 'description': asset_type_description}
     )
 
-    assert response.status_code == 200
+    assert response.status_code == 201
 
     cur: cursor = postgresql.cursor()
     cur.execute(
@@ -127,6 +135,14 @@ def test_asset_types_register(postgresql: connection):
     cur.close()
     assert len(results) == 1
     assert results[0][1] == asset_type_description
+
+    # existing asset type registration
+    response = client.post(
+        '/asset_types/register',
+        json={'id': asset_type_id, 'description': asset_type_description}
+    )
+
+    assert response.status_code == 200
 
     # registration of asset type with broken asset type ID (contains spaces)
     asset_type_id = 'this is broken'
@@ -407,6 +423,18 @@ def test_assets_topio_id(postgresql: connection):
         'owner_namespace': owner_namespace,
         'asset_id': asset_2_id,
         'asset_type': asset_type_id})
+
+    # Calling /assets/topio_id for non-existent asset registration should
+    # return an error with 404 status code
+    response = client.get(
+        '/assets/topio_id',
+        json={
+            'owner_id': 0,
+            'asset_type': asset_type_id,
+            'local_id': asset_2_local_id})
+
+    assert response.status_code == 404
+    assert response.content == b'No topio ID found for the given parameters'
 
 
 def test_assets_custom_id(postgresql: connection):


### PR DESCRIPTION
Changes proposed in this pull request:

- In [API Gateway](https://github.com/OpertusMundi/api-gateway-service) and [BPM worker service](https://github.com/OpertusMundi/bpm-worker-service), we are using [Feign clients](https://spring.io/projects/spring-cloud-openfeign) for calling external services. Internally, a Feign client is using Apache Http Client. The client does not support GET requests with a request body. If a request body is present, the request method is automatically switched to POST. As a result, we cannot invoke `/assets/topio_id` action. I have rewritten the action to get parameters from the query.

- If a workflow instance attempts to retry the asset registration operation, a new PID is returned. To avoid creating new PIDs for the same asset due to retry operations, we are using the `/assets/topio_id` action. The latter returns a 500-status code when a local id cannot be resolved to a topio id. Hence, the BPM engine cannot decide if the service call has failed (retry of the `/assets/topio_id` action is required) or the asset is not registered (`/assets/register` action must be called). I have made the following changes:

1. For user registration, if the user already exists, status code 200 is returned. If the user is created, status code 201 is returned (to avoid querying if the user exists)
2. For asset type registration: Same as user registration.
3. For `/asset/topio_id` action, status code 404 is returned when a valid PID is not found

@patrickwestphal 
